### PR TITLE
chore: explicitly list dependencies

### DIFF
--- a/bench/convert_maps.ts
+++ b/bench/convert_maps.ts
@@ -10,8 +10,8 @@
  * The given version must be a released version on JSR.
  */
 
-import { expandGlob } from "jsr:@std/fs";
-import { parseArgs } from "jsr:@std/cli/parse-args";
+import { expandGlob } from "@std/fs";
+import { parseArgs } from "@std/cli/parse-args";
 import { encode } from "../src/mod.ts";
 
 if (import.meta.main) {

--- a/bench/decode.bench.ts
+++ b/bench/decode.bench.ts
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { expandGlob } from "jsr:@std/fs";
-import { format } from "jsr:@std/fmt/bytes";
+import { expandGlob } from "@std/fs";
+import { format } from "@std/fmt/bytes";
 
 import { decode, DecodeMode } from "../src/mod.ts";
 

--- a/bench/encode.bench.ts
+++ b/bench/encode.bench.ts
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { expandGlob } from "jsr:@std/fs";
-import { format } from "jsr:@std/fmt/bytes";
+import { expandGlob } from "@std/fs";
+import { format } from "@std/fmt/bytes";
 
 import { decode, encode } from "../src/mod.ts";
 

--- a/deno.json
+++ b/deno.json
@@ -17,5 +17,12 @@
       "bench",
       "src/**/*.test.ts"
     ]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.17",
+    "@std/cli": "jsr:@std/cli@^1.0.26",
+    "@std/fmt": "jsr:@std/fmt@^1.0.9",
+    "@std/fs": "jsr:@std/fs@^1.0.22",
+    "@std/testing": "jsr:@std/testing@^1.0.17"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,50 +1,73 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "jsr:@chrome-devtools/source-map-scopes-codec@0.2.0": "0.2.0",
-    "jsr:@std/assert@*": "1.0.11",
-    "jsr:@std/assert@^1.0.10": "1.0.11",
-    "jsr:@std/cli@*": "1.0.6",
-    "jsr:@std/fmt@*": "1.0.6",
-    "jsr:@std/fs@*": "1.0.5",
-    "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/path@^1.0.7": "1.0.8",
-    "jsr:@std/testing@*": "1.0.9"
+    "jsr:@std/assert@^1.0.17": "1.0.17",
+    "jsr:@std/async@^1.1.0": "1.1.0",
+    "jsr:@std/cli@^1.0.26": "1.0.26",
+    "jsr:@std/data-structures@^1.0.10": "1.0.10",
+    "jsr:@std/fmt@^1.0.9": "1.0.9",
+    "jsr:@std/fs@^1.0.22": "1.0.22",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@^1.0.17": "1.0.17"
   },
   "jsr": {
-    "@chrome-devtools/source-map-scopes-codec@0.2.0": {
-      "integrity": "e538be2e43240628650abc2b3a0daf255755718932380b950a96b0b170318230"
-    },
-    "@std/assert@1.0.11": {
-      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
+    "@std/assert@1.0.17": {
+      "integrity": "df5ebfffe77c03b3fa1401e11c762cc8f603d51021c56c4d15a8c7ab45e90dbe",
       "dependencies": [
         "jsr:@std/internal"
       ]
     },
-    "@std/cli@1.0.6": {
-      "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
+    "@std/async@1.1.0": {
+      "integrity": "72418df08d1be84668a53e48aab3520d68ae6882182f8a5ca75c6d1f087220d1"
     },
-    "@std/fmt@1.0.6": {
-      "integrity": "a2c56a69a2369876ddb3ad6a500bb6501b5bad47bb3ea16bfb0c18974d2661fc"
-    },
-    "@std/fs@1.0.5": {
-      "integrity": "41806ad6823d0b5f275f9849a2640d87e4ef67c51ee1b8fb02426f55e02fd44e",
+    "@std/cli@1.0.26": {
+      "integrity": "53679a2b041406f15c3ff193986852595f3d11ba7b9d4b0c71a42589662e8fb5",
       "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/data-structures@1.0.10": {
+      "integrity": "f574f86b0e07c69b9edc555fcc814b57d29258bad39fd5a34ba8a80ecf033cfe"
+    },
+    "@std/fmt@1.0.9": {
+      "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
+    },
+    "@std/fs@1.0.22": {
+      "integrity": "de0f277a58a867147a8a01bc1b181d0dfa80bfddba8c9cf2bacd6747bcec9308",
+      "dependencies": [
+        "jsr:@std/internal",
         "jsr:@std/path"
       ]
     },
-    "@std/internal@1.0.5": {
-      "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
-    "@std/path@1.0.8": {
-      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
-    },
-    "@std/testing@1.0.9": {
-      "integrity": "9bdd4ac07cb13e7594ac30e90f6ceef7254ac83a9aeaa089be0008f33aab5cd4",
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/assert@^1.0.10",
         "jsr:@std/internal"
       ]
+    },
+    "@std/testing@1.0.17": {
+      "integrity": "87bdc2700fa98249d48a17cd72413352d3d3680dcfbdb64947fd0982d6bbf681",
+      "dependencies": [
+        "jsr:@std/assert",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal",
+        "jsr:@std/path"
+      ]
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.17",
+      "jsr:@std/cli@^1.0.26",
+      "jsr:@std/fmt@^1.0.9",
+      "jsr:@std/fs@^1.0.22",
+      "jsr:@std/testing@^1.0.17"
+    ]
   }
 }

--- a/src/builder/builder.test.ts
+++ b/src/builder/builder.test.ts
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import { ScopeInfoBuilder } from "./builder.ts";
 import {
   assertEquals,
   assertNotStrictEquals,
   assertStrictEquals,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 describe("ScopeInfoBuilder", () => {
   let builder: ScopeInfoBuilder;

--- a/src/builder/safe_builder.test.ts
+++ b/src/builder/safe_builder.test.ts
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import { SafeScopeInfoBuilder } from "./safe_builder.ts";
-import { assertThrows } from "jsr:@std/assert";
+import { assertThrows } from "@std/assert";
 
 describe("SafeScopeInfoBuilder", () => {
   let builder: SafeScopeInfoBuilder;

--- a/src/decode/decode.test.ts
+++ b/src/decode/decode.test.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { describe, it } from "jsr:@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { ScopeInfoBuilder } from "../builder/builder.ts";
 import { encode } from "../encode/encode.ts";
 import {
@@ -10,7 +10,7 @@ import {
   assertExists,
   assertStrictEquals,
   assertThrows,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import { encodeSigned, encodeUnsigned } from "../vlq.ts";
 import { decode, DecodeMode } from "./decode.ts";
 import type { IndexSourceMapJson, SourceMapJson } from "../scopes.ts";

--- a/src/encode/encode.test.ts
+++ b/src/encode/encode.test.ts
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import type { ScopeInfo, SourceMapJson } from "../scopes.ts";
-import { assertStrictEquals, assertThrows } from "jsr:@std/assert";
+import { assertStrictEquals, assertThrows } from "@std/assert";
 import { encode } from "./encode.ts";
 import { ScopeInfoBuilder } from "../builder/builder.ts";
 

--- a/src/roundtrip.test.ts
+++ b/src/roundtrip.test.ts
@@ -7,11 +7,11 @@
  * check that the same `ScopesInfo` falls out.
  */
 
-import { beforeEach, describe, it } from "jsr:@std/testing/bdd";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import type { ScopeInfo } from "./scopes.ts";
 import { encode } from "./encode/encode.ts";
 import { decode } from "./decode/decode.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { ScopeInfoBuilder } from "./builder/builder.ts";
 
 function assertCodec(scopesInfo: ScopeInfo): void {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { assertGreater, assertLess, assertStrictEquals } from "jsr:@std/assert";
-import { describe, it } from "jsr:@std/testing/bdd";
+import { assertGreater, assertLess, assertStrictEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
 import { comparePositions } from "./util.ts";
 
 describe("comparePositions", () => {

--- a/src/vlq.test.ts
+++ b/src/vlq.test.ts
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import { describe, it } from "jsr:@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { TokenIterator } from "./vlq.ts";
-import { assertFalse, assertStrictEquals } from "jsr:@std/assert";
+import { assertFalse, assertStrictEquals } from "@std/assert";
 
 describe("TokenIterator", () => {
   describe("nextUnsignedVLQ", () => {


### PR DESCRIPTION
This fixes new lint warnings enabled by default in 2.5 or 2.6