### PR TITLE
feat: Add indicator in decoding result whether variables and binding expressions are present

### DIFF
--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -10,11 +10,11 @@ import {
   Tag,
 } from "../codec.ts";
 import type {
+  DecodedScopeInfo,
   GeneratedRange,
   IndexSourceMapJson,
   OriginalScope,
   Position,
-  ScopeInfo,
   SourceMap,
   SourceMapJson,
   SubRangeBinding,
@@ -60,7 +60,7 @@ export const DEFAULT_DECODE_OPTIONS: DecodeOptions = {
 export function decode(
   sourceMap: SourceMap,
   options: Partial<DecodeOptions> = DEFAULT_DECODE_OPTIONS,
-): ScopeInfo {
+): DecodedScopeInfo {
   const opts = { ...DEFAULT_DECODE_OPTIONS, ...options };
   if ("sections" in sourceMap) {
     return decodeIndexMap(sourceMap, {
@@ -74,8 +74,10 @@ export function decode(
 function decodeMap(
   sourceMap: SourceMapJson,
   options: DecodeOptions,
-): ScopeInfo {
-  if (!sourceMap.scopes || !sourceMap.names) return { scopes: [], ranges: [] };
+): DecodedScopeInfo {
+  if (!sourceMap.scopes || !sourceMap.names) {
+    return { scopes: [], ranges: [], hasVariableAndBindingInfo: false };
+  }
 
   return new Decoder(sourceMap.scopes, sourceMap.names, options).decode();
 }
@@ -83,16 +85,21 @@ function decodeMap(
 function decodeIndexMap(
   sourceMap: IndexSourceMapJson,
   options: DecodeOptions,
-): ScopeInfo {
-  const scopeInfo: ScopeInfo = { scopes: [], ranges: [] };
+): DecodedScopeInfo {
+  const scopeInfo: DecodedScopeInfo = {
+    scopes: [],
+    ranges: [],
+    hasVariableAndBindingInfo: false,
+  };
 
   for (const section of sourceMap.sections) {
-    const { scopes, ranges } = decode(section.map, {
+    const { scopes, ranges, hasVariableAndBindingInfo } = decode(section.map, {
       ...options,
       generatedOffset: section.offset,
     });
     for (const scope of scopes) scopeInfo.scopes.push(scope);
     for (const range of ranges) scopeInfo.ranges.push(range);
+    scopeInfo.hasVariableAndBindingInfo ||= hasVariableAndBindingInfo;
   }
 
   return scopeInfo;
@@ -132,6 +139,9 @@ class Decoder {
     Map<number, [number, number, number][]>
   >();
 
+  #seenOriginalScopeVariables = false;
+  #seenGeneratedRangeBindings = false;
+
   constructor(scopes: string, names: string[], options: DecodeOptions) {
     this.#encodedScopes = scopes;
     this.#names = names;
@@ -140,7 +150,7 @@ class Decoder {
     this.#rangeState.column = options.generatedOffset.column;
   }
 
-  decode(): ScopeInfo {
+  decode(): DecodedScopeInfo {
     const iter = new TokenIterator(this.#encodedScopes);
 
     while (iter.hasNext()) {
@@ -175,6 +185,7 @@ class Decoder {
           }
 
           this.#handleOriginalScopeVariablesItem(variableIdxs);
+          this.#seenOriginalScopeVariables = true;
           break;
         }
         case Tag.ORIGINAL_SCOPE_END: {
@@ -224,6 +235,7 @@ class Decoder {
           }
 
           this.#handleGeneratedRangeBindingsItem(valueIdxs);
+          this.#seenGeneratedRangeBindings = true;
           break;
         }
         case Tag.GENERATED_RANGE_SUBRANGE_BINDING: {
@@ -239,6 +251,7 @@ class Decoder {
           }
 
           this.#recordGeneratedSubRangeBindingItem(variableIndex, bindings);
+          this.#seenGeneratedRangeBindings = true;
           break;
         }
         case Tag.GENERATED_RANGE_CALL_SITE: {
@@ -275,11 +288,18 @@ class Decoder {
       );
     }
 
-    const info = { scopes: this.#scopes, ranges: this.#ranges };
+    const info = {
+      scopes: this.#scopes,
+      ranges: this.#ranges,
+      hasVariableAndBindingInfo: this.#seenOriginalScopeVariables &&
+        this.#seenGeneratedRangeBindings,
+    };
 
     this.#scopes = [];
     this.#ranges = [];
     this.#flatOriginalScopes = [];
+    this.#seenOriginalScopeVariables = false;
+    this.#seenGeneratedRangeBindings = false;
 
     return info;
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,6 +4,7 @@
 
 export type {
   Binding,
+  DecodedScopeInfo,
   GeneratedRange,
   OriginalPosition,
   OriginalScope,

--- a/src/roundtrip.test.ts
+++ b/src/roundtrip.test.ts
@@ -15,7 +15,8 @@ import { assertEquals } from "@std/assert";
 import { ScopeInfoBuilder } from "./builder/builder.ts";
 
 function assertCodec(scopesInfo: ScopeInfo): void {
-  assertEquals(decode(encode(scopesInfo)), scopesInfo);
+  const { scopes, ranges } = decode(encode(scopesInfo));
+  assertEquals({ scopes, ranges }, scopesInfo);
 }
 
 describe("round trip", () => {

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /**
- * The decoded scopes information found in a source map.
+ * The scopes information found in a source map.
  */
 export interface ScopeInfo {
   /**
@@ -15,6 +15,17 @@ export interface ScopeInfo {
    * The range tree of the generated bundle. Multiple top-level ranges are allowed but must not overlap source position wise.
    */
   ranges: GeneratedRange[];
+}
+
+/**
+ * The scopes information produced by the decoder.
+ */
+export interface DecodedScopeInfo extends ScopeInfo {
+  /**
+   * When the encoded scopes contained variable and binding expression items.
+   * Note that a value of `true` also indicates "partial" info and does not guarantee comprehensiveness.
+   */
+  hasVariableAndBindingInfo: boolean;
 }
 
 /**


### PR DESCRIPTION
Debuggers want to know whether the source map contained only info for stack traces or also variable names and binding expressions.