### PR TITLE
fix: align sub-range binding with current spec text

### DIFF
--- a/src/decode/decode.test.ts
+++ b/src/decode/decode.test.ts
@@ -468,10 +468,10 @@ describe("decode", () => {
     encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_BINDINGS, 2).finishItem();
 
     // 1st sub-range binding for variable 0. from 1,0, value is "var1" (index 1)
-    encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_SUBRANGE_BINDING, 0, 1, 1, 0)
+    encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_SUBRANGE_BINDING, 0, 1, 0, 1)
       .finishItem();
     // 2nd sub-range binding for variable 0. from 2,0, value is "baz" (index 3)
-    encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_SUBRANGE_BINDING, 0, 3, 1, 0)
+    encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_SUBRANGE_BINDING, 0, 1, 0, 3)
       .finishItem();
     encoder.addUnsignedVLQs(Tag.GENERATED_RANGE_END, 3, 0).finishItem();
     const map = createMap(encoder.encode(), ["var1", "bar", "baz"]);

--- a/src/decode/decode.ts
+++ b/src/decode/decode.ts
@@ -541,7 +541,7 @@ class Decoder {
         value: value as string | undefined,
       });
 
-      for (const [binding, line, column] of bindings) {
+      for (const [line, column, binding] of bindings) {
         lastLine += line;
         if (line === 0) {
           lastColumn += column;

--- a/src/encode/encoder.ts
+++ b/src/encode/encoder.ts
@@ -228,8 +228,8 @@ export class Encoder {
         const binding = subRange.value === undefined
           ? 0
           : this.#resolveNamesIdx(subRange.value) + 1;
-        this.#encodeUnsigned(binding).#encodeUnsigned(encodedLine)
-          .#encodeUnsigned(encodedColumn);
+        this.#encodeUnsigned(encodedLine).#encodeUnsigned(encodedColumn)
+          .#encodeUnsigned(binding);
       }
       this.#finishItem();
     }


### PR DESCRIPTION
Discovered while reviewing https://github.com/tc39/source-map-tests/pull/39.

The library encodes `<binding> <line> <column>` instead of `<line> <column> <binding>`