### PR TITLE
Reset keyToScope and lastScope in ScopeInfoBuilder.build() so a reused builder does not leak state

### DIFF
--- a/src/builder/builder.test.ts
+++ b/src/builder/builder.test.ts
@@ -368,4 +368,20 @@ describe("ScopeInfoBuilder", () => {
       assertStrictEquals(info.ranges[0].originalScope, info.scopes[0]);
     });
   });
+
+  describe("build", () => {
+    it("resets accumulated state so a reused builder does not leak across builds", () => {
+      builder.startScope(0, 0, { key: 0 }).endScope(10, 0);
+      builder.startRange(0, 0, { scopeKey: 0 }).endRange(0, 10);
+      builder.build();
+
+      // Key 0 is not registered in this second build, so the range must not
+      // resolve to a scope carried over from the previous build.
+      const info = builder.startRange(0, 0, { scopeKey: 0 }).endRange(0, 10)
+        .build();
+
+      assertStrictEquals(info.ranges[0].originalScope, undefined);
+      assertStrictEquals(builder.lastScope(), null);
+    });
+  });
 });

--- a/src/builder/builder.ts
+++ b/src/builder/builder.ts
@@ -228,6 +228,8 @@ export class ScopeInfoBuilder {
     this.#scopes = [];
     this.#ranges = [];
     this.#knownScopes.clear();
+    this.#keyToScope.clear();
+    this.#lastScope = null;
 
     return info;
   }


### PR DESCRIPTION
## Summary

`ScopeInfoBuilder.build()` returns the accumulated `ScopeInfo` and resets the builder so it can be reused. It clears `#scopes`, `#ranges`, and `#knownScopes`, but leaves `#keyToScope` and `#lastScope` populated, so state from a previous build leaks into the next one.

If you reuse a builder across two `build()` calls, a `startRange({ scopeKey })` in the second build resolves `originalScope` from a key registered during the first build, linking the range to a scope that is not part of the current tree. Encoding that result then throws `Unknown OriginalScope for definition!`. A freshly constructed builder produces no such link. `lastScope()` has the same leak: it returns a scope from the prior build after a `build()` that opened none.

## Fix

Clear `#keyToScope` and reset `#lastScope` in `build()`, alongside the existing resets.

## Test

Added a case in `builder.test.ts`: register `key: 0` and build once, then in a second build resolve `scopeKey: 0` and assert the range's `originalScope` is `undefined` (and `lastScope()` is `null`). It fails before the change and passes after.
